### PR TITLE
Adding tcp protocol flag to logic waiting SQL

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -40,7 +40,7 @@ fi
 if [ $DOLI_INSTALL_AUTO -eq 1 ]; then
   r=1
   while [ $r -ne 0 ]; do
-    mysql -u $DOLI_DB_USER -p${DOLI_DB_PASSWORD} -h $DOLI_DB_HOST -e "status" > /dev/null 2>&1
+    mysql -u $DOLI_DB_USER --protocol tcp -p${DOLI_DB_PASSWORD} -h $DOLI_DB_HOST -e "status" > /dev/null 2>&1
     r=$?
     if [ $r -ne 0 ]; then
       echo "Waiting that SQL database is up..."


### PR DESCRIPTION
In kubernetes, when you want to use inside same pod and shares network sockets, without this flag it checks '/var/run/mysqld/mysqld.sock' which is not shared.