### PR TITLE
ADD: Configurable PHP memory_limit (default 256M).

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ Remove the `install.lock` file and start an updated version container. Ensure th
 | **DOLI_ADMIN_PASSWORD**       | *admin*            | Admin'password
 | **DOLI_URL_ROOT**             | *http://localhost* | Url root of the Dolibarr installation
 | **PHP_INI_DATE_TIMEZONE**     | *UTC*              | Default timezone on PHP
+| **PHP_INI_MEMORY_LIMIT**      | *256M*             | PHP Memory limit
 | **WWW_USER_ID**               |                    | ID of user www-data. ID will not changed if leave empty. During a development, it is very practical to put the same ID as the host user.
 | **WWW_GROUP_ID**              |                    | ID of group www-data. ID will not changed if leave empty.

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/10.0.7-php5.6/Dockerfile
+++ b/images/10.0.7-php5.6/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/10.0.7-php5.6/docker-run.sh
+++ b/images/10.0.7-php5.6/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/10.0.7-php7.3/Dockerfile
+++ b/images/10.0.7-php7.3/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/10.0.7-php7.3/docker-run.sh
+++ b/images/10.0.7-php7.3/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/11.0.5-php5.6/Dockerfile
+++ b/images/11.0.5-php5.6/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/11.0.5-php5.6/docker-run.sh
+++ b/images/11.0.5-php5.6/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/11.0.5-php7.4/Dockerfile
+++ b/images/11.0.5-php7.4/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/11.0.5-php7.4/docker-run.sh
+++ b/images/11.0.5-php7.4/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/12.0.1-php5.6/Dockerfile
+++ b/images/12.0.1-php5.6/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/12.0.1-php5.6/docker-run.sh
+++ b/images/12.0.1-php5.6/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/12.0.1-php7.4/Dockerfile
+++ b/images/12.0.1-php7.4/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/12.0.1-php7.4/docker-run.sh
+++ b/images/12.0.1-php7.4/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/6.0.8-php5.6/Dockerfile
+++ b/images/6.0.8-php5.6/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/6.0.8-php5.6/docker-run.sh
+++ b/images/6.0.8-php5.6/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/6.0.8-php7.1/Dockerfile
+++ b/images/6.0.8-php7.1/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/6.0.8-php7.1/docker-run.sh
+++ b/images/6.0.8-php7.1/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/7.0.5-php5.6/Dockerfile
+++ b/images/7.0.5-php5.6/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/7.0.5-php5.6/docker-run.sh
+++ b/images/7.0.5-php5.6/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/7.0.5-php7.2/Dockerfile
+++ b/images/7.0.5-php7.2/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/7.0.5-php7.2/docker-run.sh
+++ b/images/7.0.5-php7.2/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/8.0.6-php5.6/Dockerfile
+++ b/images/8.0.6-php5.6/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/8.0.6-php5.6/docker-run.sh
+++ b/images/8.0.6-php5.6/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/8.0.6-php7.2/Dockerfile
+++ b/images/8.0.6-php7.2/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/8.0.6-php7.2/docker-run.sh
+++ b/images/8.0.6-php7.2/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/9.0.4-php5.6/Dockerfile
+++ b/images/9.0.4-php5.6/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/9.0.4-php5.6/docker-run.sh
+++ b/images/9.0.4-php5.6/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then

--- a/images/9.0.4-php7.3/Dockerfile
+++ b/images/9.0.4-php7.3/Dockerfile
@@ -18,6 +18,7 @@ ENV WWW_USER_ID 33
 ENV WWW_GROUP_ID 33
 
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \

--- a/images/9.0.4-php7.3/docker-run.sh
+++ b/images/9.0.4-php7.3/docker-run.sh
@@ -12,6 +12,7 @@ function initDolibarr()
   cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
 date.timezone = ${PHP_INI_DATE_TIMEZONE}
 sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = $PHP_INI_MEMORY_LIMIT
 EOF
 
   if [ ! -f /var/www/html/conf/conf.php ]; then


### PR DESCRIPTION
Default memory limit of 128M is an issue with Dolibarr since early versions, especially when it comes to generate documents using ODT templates or PDF modules (with background or images).

Picking up the idea of Feyks, let's increase the default and make it configurable on container start.

Review welcome ;-)