### PR TITLE
Add "libreoffice-writer" to the Dockerfile.template file

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd %GD_CONFIG_ARG% \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/10.0.7-php5.6/Dockerfile
+++ b/images/10.0.7-php5.6/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/10.0.7-php7.3/Dockerfile
+++ b/images/10.0.7-php7.3/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/11.0.5-php5.6/Dockerfile
+++ b/images/11.0.5-php5.6/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/11.0.5-php7.4/Dockerfile
+++ b/images/11.0.5-php7.4/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/12.0.4-php5.6/Dockerfile
+++ b/images/12.0.4-php5.6/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/12.0.4-php7.4/Dockerfile
+++ b/images/12.0.4-php7.4/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/13.0.3-php7.4/Dockerfile
+++ b/images/13.0.3-php7.4/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/7.0.5-php5.6/Dockerfile
+++ b/images/7.0.5-php5.6/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/7.0.5-php7.2/Dockerfile
+++ b/images/7.0.5-php7.2/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/8.0.6-php5.6/Dockerfile
+++ b/images/8.0.6-php5.6/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/8.0.6-php7.2/Dockerfile
+++ b/images/8.0.6-php7.2/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/9.0.4-php5.6/Dockerfile
+++ b/images/9.0.4-php5.6/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/9.0.4-php7.3/Dockerfile
+++ b/images/9.0.4-php7.3/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y \
         libzip-dev \
         default-mysql-client \
         unzip \
+        libreoffice-writer \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \


### PR DESCRIPTION
With the `MAIN_ODT_AS_PDF` PDF option Dolibarr is able to automatically convert .odt files to .pdf files. For this feature to work libreoffice-writer has to be installed in the container.

Please pull.