### PR TITLE
squeeze ~70 MiB from OCI image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd %GD_CONFIG_ARG% \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION %DOLI_VERSION%
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/10.0.7-php5.6/Dockerfile
+++ b/images/10.0.7-php5.6/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 10.0.7
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/10.0.7-php7.3/Dockerfile
+++ b/images/10.0.7-php7.3/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 10.0.7
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/11.0.5-php5.6/Dockerfile
+++ b/images/11.0.5-php5.6/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 11.0.5
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/11.0.5-php7.4/Dockerfile
+++ b/images/11.0.5-php7.4/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 11.0.5
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/12.0.5-php5.6/Dockerfile
+++ b/images/12.0.5-php5.6/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 12.0.5
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/12.0.5-php7.4/Dockerfile
+++ b/images/12.0.5-php7.4/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 12.0.5
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/13.0.4-php7.4/Dockerfile
+++ b/images/13.0.4-php7.4/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 13.0.4
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/14.0.0-php7.4/Dockerfile
+++ b/images/14.0.0-php7.4/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 14.0.0
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/7.0.5-php5.6/Dockerfile
+++ b/images/7.0.5-php5.6/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 7.0.5
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/7.0.5-php7.2/Dockerfile
+++ b/images/7.0.5-php7.2/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 7.0.5
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/8.0.6-php5.6/Dockerfile
+++ b/images/8.0.6-php5.6/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 8.0.6
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/8.0.6-php7.2/Dockerfile
+++ b/images/8.0.6-php7.2/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 8.0.6
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/9.0.4-php5.6/Dockerfile
+++ b/images/9.0.4-php5.6/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 9.0.4
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/9.0.4-php7.3/Dockerfile
+++ b/images/9.0.4-php7.3/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION 9.0.4
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
-        unzip \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -54,11 +53,11 @@ RUN apt-get update -y \
 ENV DOLI_VERSION develop
 
 # Get Dolibarr
-ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip
-RUN unzip -q /tmp/dolibarr.zip -d /tmp/dolibarr && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
     ln -s /var/www/html /var/www/htdocs && \
-    cp -r /tmp/dolibarr/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
     chown -R www-data:www-data /var/www


### PR DESCRIPTION
ADD instruction create a new layer whose content is still present in the final image even if a future RUN command seemly remove it.

Note:
- [`dive`](https://github.com/wagoodman/dive) ease the visualization of the intermediate layers size; this PR removes the ~70 MiB from the Dolibarr archive.
- I can shrink another ~10 MiB by running a script to deduplicate (hardlinking) similar files; let me know if you want to see it.