### PR TITLE
Feature/add postgres support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd %GD_CONFIG_ARG% \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Docker image for Dolibarr with auto installer on first boot.
 * 11.0.5-php7.4 11.0.5 11
 * 12.0.5-php7.4 12.0.5 12
 * 13.0.4-php7.4 13.0.4 13
-* 14.0.5-php7.4 14.0.5 14 latest
+* 14.0.5-php7.4 14.0.5 14
+* 15.0.0-php7.4 15.0.0 15 latest
 * develop
 
 **End of support for PHP < 7.3**

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ You can find several examples in the `examples` directory, such as:
 ## Upgrading version and migrating DB
 The `install.lock` file is located inside the container volume `/var/www/documents`.
 
+## Early support for PostgreSQL
+Setting `DOLI_DB_TYPE` to `pgsql` enable Dolibarr to run with a PostgreSQL database.
+When set to use `pgsql`, Dolibarr must be installed manually on it's first execution:
+ - Browse to `http://0.0.0.0/install`;
+ - Follow the installation setup;
+ - Add `install.lock` inside the container volume `/var/www/html/documents` (ex `docker-compose exec services-data_dolibarr_1 /bin/bash -c "touch /var/www/html/documents/install.lock"`).
+
 Remove the `install.lock` file and start an updated version container. Ensure that env `DOLI_INSTALL_AUTO` is set to `1`. It will migrate Database to the new version.
 You can still use the standard way to upgrade through web interface.
 
@@ -78,6 +85,7 @@ You can still use the standard way to upgrade through web interface.
 | Variable                      | Default value                  | Description |
 | ----------------------------- | ------------------------------ | ----------- |
 | **DOLI_INSTALL_AUTO**         | *1*                            | 1: The installation will be executed on first boot
+| **DOLI_DB_TYPE**              | *mysqli*                       | Type of the DB server (**mysqli**, pgsql)
 | **DOLI_DB_HOST**              | *mysql*                        | Host name of the MariaDB/MySQL server
 | **DOLI_DB_HOST_PORT**         | *3306*                         | Host port of the MariaDB/MySQL server
 | **DOLI_DB_USER**              | *doli*                         | Database user

--- a/README.template
+++ b/README.template
@@ -62,6 +62,13 @@ You can find several examples in the `examples` directory, such as:
 ## Upgrading version and migrating DB
 The `install.lock` file is located inside the container volume `/var/www/documents`.
 
+## Early support for PostgreSQL
+Setting `DOLI_DB_TYPE` to `pgsql` enable Dolibarr to run with a PostgreSQL database.
+When set to use `pgsql`, Dolibarr must be installed manually on it's first execution:
+ - Browse to `http://0.0.0.0/install`;
+ - Follow the installation setup;
+ - Add `install.lock` inside the container volume `/var/www/html/documents` (ex `docker-compose exec services-data_dolibarr_1 /bin/bash -c "touch /var/www/html/documents/install.lock"`).
+
 Remove the `install.lock` file and start an updated version container. Ensure that env `DOLI_INSTALL_AUTO` is set to `1`. It will migrate Database to the new version.
 You can still use the standard way to upgrade through web interface.
 
@@ -70,6 +77,7 @@ You can still use the standard way to upgrade through web interface.
 | Variable                      | Default value                  | Description |
 | ----------------------------- | ------------------------------ | ----------- |
 | **DOLI_INSTALL_AUTO**         | *1*                            | 1: The installation will be executed on first boot
+| **DOLI_DB_TYPE**              | *mysqli*                       | Type of the DB server (**mysqli**, pgsql)
 | **DOLI_DB_HOST**              | *mysql*                        | Host name of the MariaDB/MySQL server
 | **DOLI_DB_HOST_PORT**         | *3306*                         | Host port of the MariaDB/MySQL server
 | **DOLI_DB_USER**              | *doli*                         | Database user

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/10.0.7-php7.3/Dockerfile
+++ b/images/10.0.7-php7.3/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/10.0.7-php7.3/docker-run.sh
+++ b/images/10.0.7-php7.3/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/11.0.5-php7.4/Dockerfile
+++ b/images/11.0.5-php7.4/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/11.0.5-php7.4/docker-run.sh
+++ b/images/11.0.5-php7.4/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/12.0.5-php7.4/Dockerfile
+++ b/images/12.0.5-php7.4/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/12.0.5-php7.4/docker-run.sh
+++ b/images/12.0.5-php7.4/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/13.0.4-php7.4/Dockerfile
+++ b/images/13.0.4-php7.4/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/13.0.4-php7.4/docker-run.sh
+++ b/images/13.0.4-php7.4/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/14.0.5-php7.4/Dockerfile
+++ b/images/14.0.5-php7.4/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/14.0.5-php7.4/docker-run.sh
+++ b/images/14.0.5-php7.4/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/15.0.0-php7.4/Dockerfile
+++ b/images/15.0.0-php7.4/Dockerfile
@@ -1,0 +1,75 @@
+FROM php:7.4-apache-buster
+
+LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
+
+ENV DOLI_INSTALL_AUTO 1
+
+ENV DOLI_DB_HOST mysql
+ENV DOLI_DB_HOST_PORT 3306
+ENV DOLI_DB_NAME dolidb
+
+ENV DOLI_URL_ROOT 'http://localhost'
+ENV DOLI_NOCSRFCHECK 0
+
+ENV DOLI_AUTH dolibarr
+ENV DOLI_LDAP_HOST 127.0.0.1
+ENV DOLI_LDAP_PORT 389
+ENV DOLI_LDAP_VERSION 3
+ENV DOLI_LDAP_SERVER_TYPE openldap
+ENV DOLI_LDAP_LOGIN_ATTRIBUTE uid
+ENV DOLI_LDAP_DN 'ou=users,dc=my-domain,dc=com'
+ENV DOLI_LDAP_FILTER ''
+ENV DOLI_LDAP_BIND_DN ''
+ENV DOLI_LDAP_BIND_PASS ''
+ENV DOLI_LDAP_DEBUG false
+
+ENV WWW_USER_ID 33
+ENV WWW_GROUP_ID 33
+
+ENV PHP_INI_DATE_TIMEZONE 'UTC'
+ENV PHP_INI_MEMORY_LIMIT 256M
+
+RUN apt-get update -y \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        libc-client-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libkrb5-dev \
+        libldap2-dev \
+        libpng-dev \
+        libxml2-dev \
+        libzip-dev \
+        default-mysql-client \
+    && apt-get autoremove -y \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install -j$(nproc) ldap \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-install imap \
+    && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini
+
+ENV DOLI_VERSION 15.0.0
+
+# Get Dolibarr
+RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\
+    tar -C /tmp -xz && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/htdocs/* /var/www/html/ && \
+    ln -s /var/www/html /var/www/htdocs && \
+    cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
+    rm -rf /tmp/* && \
+    mkdir -p /var/www/documents && \
+    mkdir -p /var/www/html/custom && \
+    chown -R www-data:www-data /var/www
+
+RUN rm -rf /var/lib/apt/lists/*
+
+EXPOSE 80
+VOLUME /var/www/documents
+VOLUME /var/www/html/custom
+
+COPY docker-run.sh /usr/local/bin/
+ENTRYPOINT ["docker-run.sh"]
+
+CMD ["apache2-foreground"]

--- a/images/15.0.0-php7.4/Dockerfile
+++ b/images/15.0.0-php7.4/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/15.0.0-php7.4/docker-run.sh
+++ b/images/15.0.0-php7.4/docker-run.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+# usage: get_env_value VAR [DEFAULT]
+#    ie: get_env_value 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+function get_env_value() {
+	local varName="${1}"
+	local fileVarName="${varName}_FILE"
+	local defaultValue="${2:-}"
+
+	if [ "${!varName:-}" ] && [ "${!fileVarName:-}" ]; then
+		echo >&2 "error: both ${varName} and ${fileVarName} are set (but are exclusive)"
+		exit 1
+	fi
+
+	local value="${defaultValue}"
+	if [ "${!varName:-}" ]; then
+	  value="${!varName}"
+	elif [ "${!fileVarName:-}" ]; then
+		value="$(< "${!fileVarName}")"
+	fi
+
+	echo ${value}
+	exit 0
+}
+
+function initDolibarr()
+{
+  local CURRENT_UID=$(id -u www-data)
+  local CURRENT_GID=$(id -g www-data)
+  usermod -u ${WWW_USER_ID} www-data
+  groupmod -g ${WWW_GROUP_ID} www-data
+
+  if [[ ! -d /var/www/documents ]]; then
+    echo "[INIT] => create volume directory /var/www/documents ..."
+    mkdir -p /var/www/documents
+  fi
+
+  echo "[INIT] => update PHP Config ..."
+  cat > ${PHP_INI_DIR}/conf.d/dolibarr-php.ini << EOF
+date.timezone = ${PHP_INI_DATE_TIMEZONE}
+sendmail_path = /usr/sbin/sendmail -t -i
+memory_limit = ${PHP_INI_MEMORY_LIMIT}
+EOF
+
+if [[ ! -f /var/www/html/conf/conf.php ]]; then
+    echo "[INIT] => update Dolibarr Config ..."
+    cat > /var/www/html/conf/conf.php << EOF
+<?php
+\$dolibarr_main_url_root='${DOLI_URL_ROOT}';
+\$dolibarr_main_document_root='/var/www/html';
+\$dolibarr_main_url_root_alt='/custom';
+\$dolibarr_main_document_root_alt='/var/www/html/custom';
+\$dolibarr_main_data_root='/var/www/documents';
+\$dolibarr_main_db_host='${DOLI_DB_HOST}';
+\$dolibarr_main_db_port='${DOLI_DB_HOST_PORT}';
+\$dolibarr_main_db_name='${DOLI_DB_NAME}';
+\$dolibarr_main_db_prefix='llx_';
+\$dolibarr_main_db_user='${DOLI_DB_USER}';
+\$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
+\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_authentication='${DOLI_AUTH}';
+EOF
+    if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
+      echo "[INIT] => update Dolibarr Config with LDAP entries ..."
+      cat >> /var/www/html/conf/conf.php << EOF
+\$dolibarr_main_auth_ldap_host='${DOLI_LDAP_HOST}';
+\$dolibarr_main_auth_ldap_port='${DOLI_LDAP_PORT}';
+\$dolibarr_main_auth_ldap_version='${DOLI_LDAP_VERSION}';
+\$dolibarr_main_auth_ldap_servertype='${DOLI_LDAP_SERVER_TYPE}';
+\$dolibarr_main_auth_ldap_login_attribute='${DOLI_LDAP_LOGIN_ATTRIBUTE}';
+\$dolibarr_main_auth_ldap_dn='${DOLI_LDAP_DN}';
+\$dolibarr_main_auth_ldap_filter='${DOLI_LDAP_FILTER}';
+\$dolibarr_main_auth_ldap_admin_login='${DOLI_LDAP_BIND_DN}';
+\$dolibarr_main_auth_ldap_admin_pass='${DOLI_LDAP_BIND_PASS}';
+\$dolibarr_main_auth_ldap_debug='${DOLI_LDAP_DEBUG}';
+EOF
+    fi
+  fi
+
+  echo "[INIT] => update ownership for file in Dolibarr Config ..."
+  chown www-data:www-data /var/www/html/conf/conf.php
+  chmod 400 /var/www/html/conf/conf.php
+
+  if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
+    # Refresh file ownership cause it has changed
+    echo "[INIT] => As UID / GID have changed from default, update ownership for files in /var/ww ..."
+    chown -R www-data:www-data /var/www
+  else
+    # Reducing load on init : change ownership only for volumes declared in docker
+    echo "[INIT] => update ownership for files in /var/www/documents ..."
+    chown -R www-data:www-data /var/www/documents
+  fi
+}
+
+function waitForDataBase()
+{
+  r=1
+
+  while [[ ${r} -ne 0 ]]; do
+    mysql -u ${DOLI_DB_USER} --protocol tcp -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} -e "status" > /dev/null 2>&1
+    r=$?
+    if [[ ${r} -ne 0 ]]; then
+      echo "Waiting that SQL database is up ..."
+      sleep 2
+    fi
+  done
+}
+
+function lockInstallation()
+{
+  touch /var/www/documents/install.lock
+  chown www-data:www-data /var/www/documents/install.lock
+  chmod 400 /var/www/documents/install.lock
+}
+
+function initializeDatabase()
+{
+  for fileSQL in /var/www/html/install/mysql/tables/*.sql; do
+    if [[ ${fileSQL} != *.key.sql ]]; then
+      echo "Importing table from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL} # remove all comment
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL}
+    fi
+  done
+
+  for fileSQL in /var/www/html/install/mysql/tables/*.key.sql; do
+    echo "Importing table key from `basename ${fileSQL}` ..."
+    sed -i 's/--.*//g;' ${fileSQL}
+    mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+  done
+
+  for fileSQL in /var/www/html/install/mysql/functions/*.sql; do
+    echo "Importing `basename ${fileSQL}` ..."
+    sed -i 's/--.*//g;' ${fileSQL}
+    mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+  done
+
+  for fileSQL in /var/www/html/install/mysql/data/*.sql; do
+    echo "Importing data from `basename ${fileSQL}` ..."
+    sed -i 's/--.*//g;' ${fileSQL}
+    mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+  done
+
+  echo "Create SuperAdmin account ..."
+  pass_crypted=`echo -n ${DOLI_ADMIN_PASSWORD} | md5sum | awk '{print $1}'`
+  mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "INSERT INTO llx_user (entity, login, pass_crypted, lastname, admin, statut) VALUES (0, '${DOLI_ADMIN_LOGIN}', '${pass_crypted}', 'SuperAdmin', 1, 1);" > /dev/null 2>&1
+
+  echo "Set some default const ..."
+  mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "DELETE FROM llx_const WHERE name='MAIN_VERSION_LAST_INSTALL';" > /dev/null 2>&1
+  mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "DELETE FROM llx_const WHERE name='MAIN_NOT_INSTALLED';" > /dev/null 2>&1
+  mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "DELETE FROM llx_const WHERE name='MAIN_LANG_DEFAULT';" > /dev/null 2>&1
+  mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "INSERT INTO llx_const(name,value,type,visible,note,entity) values('MAIN_VERSION_LAST_INSTALL', '${DOLI_VERSION}', 'chaine', 0, 'Dolibarr version when install', 0);" > /dev/null 2>&1
+  mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "INSERT INTO llx_const(name,value,type,visible,note,entity) VALUES ('MAIN_LANG_DEFAULT', 'auto', 'chaine', 0, 'Default language', 1);" > /dev/null 2>&1
+}
+
+function migrateDatabase()
+{
+  TARGET_VERSION="$(echo ${DOLI_VERSION} | cut -d. -f1).$(echo ${DOLI_VERSION} | cut -d. -f2).0"
+  echo "Schema update is required ..."
+  echo "Dumping Database into /var/www/documents/dump.sql ..."
+
+  mysqldump -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} > /var/www/documents/dump.sql
+  r=${?}
+  if [[ ${r} -ne 0 ]]; then
+    echo "Dump failed ... Aborting migration ..."
+    return ${r}
+  fi
+  echo "Dump done ... Starting Migration ..."
+
+  echo "" > /var/www/documents/migration_error.html
+  pushd /var/www/htdocs/install > /dev/null
+  php upgrade.php ${INSTALLED_VERSION} ${TARGET_VERSION} >> /var/www/documents/migration_error.html 2>&1 && \
+  php upgrade2.php ${INSTALLED_VERSION} ${TARGET_VERSION} >> /var/www/documents/migration_error.html 2>&1 && \
+  php step5.php ${INSTALLED_VERSION} ${TARGET_VERSION} >> /var/www/documents/migration_error.html 2>&1
+  r=$?
+  popd > /dev/null
+
+  if [[ ${r} -ne 0 ]]; then
+    echo "Migration failed ... Restoring DB ... check file /var/www/documents/migration_error.html for more info on error ..."
+    mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < /var/www/documents/dump.sql
+    echo "DB Restored ..."
+    return ${r}
+  else
+    echo "Migration successful ... Enjoy !!"
+  fi
+
+  return 0
+}
+
+function run()
+{
+  initDolibarr
+  echo "Current Version is : ${DOLI_VERSION}"
+
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+    waitForDataBase
+
+    mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1
+    r=$?
+    if [[ ${r} -ne 0 ]]; then
+      initializeDatabase
+    else
+      INSTALLED_VERSION=`grep -v LAST_INSTALLED_VERSION /tmp/lastinstall.result`
+      echo "Last installed Version is : ${INSTALLED_VERSION}"
+      if [[ "$(echo ${INSTALLED_VERSION} | cut -d. -f1)" -lt "$(echo ${DOLI_VERSION} | cut -d. -f1)" ]]; then
+        migrateDatabase
+      else
+        echo "Schema update is not required ... Enjoy !!"
+      fi
+    fi
+
+    if [[ ${DOLI_VERSION} != "develop" ]]; then
+      lockInstallation
+    fi
+  fi
+}
+
+DOLI_DB_USER=$(get_env_value 'DOLI_DB_USER' 'doli')
+DOLI_DB_PASSWORD=$(get_env_value 'DOLI_DB_PASSWORD' 'doli_pass')
+DOLI_ADMIN_LOGIN=$(get_env_value 'DOLI_ADMIN_LOGIN' 'admin')
+DOLI_ADMIN_PASSWORD=$(get_env_value 'DOLI_ADMIN_PASSWORD' 'admin')
+
+run
+
+set -e
+
+if [ "${1#-}" != "$1" ]; then
+  set -- apache2-foreground "$@"
+fi
+
+exec "$@"

--- a/images/15.0.0-php7.4/docker-run.sh
+++ b/images/15.0.0-php7.4/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/9.0.4-php7.3/Dockerfile
+++ b/images/9.0.4-php7.3/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/9.0.4-php7.3/docker-run.sh
+++ b/images/9.0.4-php7.3/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/images/develop/Dockerfile
+++ b/images/develop/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Garcia MICHEL <garcia@soamichel.fr>"
 
 ENV DOLI_INSTALL_AUTO 1
 
+ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST mysql
 ENV DOLI_DB_HOST_PORT 3306
 ENV DOLI_DB_NAME dolidb
@@ -38,12 +39,16 @@ RUN apt-get update -y \
         libkrb5-dev \
         libldap2-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libzip-dev \
         default-mysql-client \
+        postgresql-client \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-configure pgsql -with-pgsql \
+    && docker-php-ext-install pdo_pgsql pgsql \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \

--- a/images/develop/docker-run.sh
+++ b/images/develop/docker-run.sh
@@ -59,7 +59,7 @@ if [[ ! -f /var/www/html/conf/conf.php ]]; then
 \$dolibarr_main_db_prefix='llx_';
 \$dolibarr_main_db_user='${DOLI_DB_USER}';
 \$dolibarr_main_db_pass='${DOLI_DB_PASSWORD}';
-\$dolibarr_main_db_type='mysqli';
+\$dolibarr_main_db_type='${DOLI_DB_TYPE}';
 \$dolibarr_main_authentication='${DOLI_AUTH}';
 EOF
     if [[ ${DOLI_AUTH} =~ .*ldap.* ]]; then
@@ -81,7 +81,11 @@ EOF
 
   echo "[INIT] => update ownership for file in Dolibarr Config ..."
   chown www-data:www-data /var/www/html/conf/conf.php
-  chmod 400 /var/www/html/conf/conf.php
+  if [[ ${DOLI_DB_TYPE} == "pgsql" ]]; then
+    chmod 600 /var/www/html/conf/conf.php
+  else
+    chmod 400 /var/www/html/conf/conf.php
+  fi
 
   if [[ ${CURRENT_UID} -ne ${WWW_USER_ID} || ${CURRENT_GID} -ne ${WWW_GROUP_ID} ]]; then
     # Refresh file ownership cause it has changed
@@ -194,7 +198,7 @@ function run()
   initDolibarr
   echo "Current Version is : ${DOLI_VERSION}"
 
-  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock ]]; then
+  if [[ ${DOLI_INSTALL_AUTO} -eq 1 && ! -f /var/www/documents/install.lock && ${DOLI_DB_TYPE} != "pgsql" ]]; then
     waitForDataBase
 
     mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} -e "SELECT Q.LAST_INSTALLED_VERSION FROM (SELECT INET_ATON(CONCAT(value, REPEAT('.0', 3 - CHAR_LENGTH(value) + CHAR_LENGTH(REPLACE(value, '.', ''))))) as VERSION_ATON, value as LAST_INSTALLED_VERSION FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_INSTALL', 'MAIN_VERSION_LAST_UPGRADE') and entity=0) Q ORDER BY VERSION_ATON DESC LIMIT 1" > /tmp/lastinstall.result 2>&1

--- a/versions.sh
+++ b/versions.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-DOLIBARR_VERSIONS=( "9.0.4" "10.0.7" "11.0.5" "12.0.5" "13.0.4" "14.0.5" "develop" )
-DOLIBARR_LATEST_TAG="14.0.5"
+DOLIBARR_VERSIONS=( "9.0.4" "10.0.7" "11.0.5" "12.0.5" "13.0.4" "14.0.5" "15.0.0" "develop" )
+DOLIBARR_LATEST_TAG="15.0.0"


### PR DESCRIPTION
Added initial support for PostgreSQL.
This enable Dolibarr to use a postgres database, but a manual installation is needed as per README.md

Next step should be to automatically setup the DB like the MySQL implementation.