### PR TITLE
Add required MySQL  root password env variable

### DIFF
--- a/examples/with-mysql/docker-compose.yml
+++ b/examples/with-mysql/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       MYSQL_DATABASE: "dolibarr"
       MYSQL_USER: "dolibarr"
       MYSQL_PASSWORD: "mysupersecretpasswordfordatabase"
+      MYSQL_ROOT_PASSWORD: "mysupersupersecretpasswordforrootuser"
     volumes:
       - mysql-data:/var/lib/mysql
     networks:


### PR DESCRIPTION
While trying to create a docker container with a MySQL database, one of the following environment variables is required to create an instance.

One of MARIADB_RANDOM_ROOT_PASSWORD, MARIADB_ROOT_PASSWORD_HASH, MARIADB_ROOT_PASSWORD or MARIADB_ALLOW_EMPTY_ROOT_PASSWORD (or equivalents, including *_FILE), is required (or any variation with MYSQL_*).

See https://hub.docker.com/_/mariadb