### PR TITLE
fix: dolibarr security alerts

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -80,8 +80,12 @@ RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.
     cp -r /tmp/dolibarr-${DOLI_VERSION}/scripts /var/www/ && \
     rm -rf /tmp/* && \
     mkdir -p /var/www/documents && \
+    chmod -R 655 /var/www/documents && \
     mkdir -p /var/www/html/custom && \
-    chown -R www-data:www-data /var/www
+    chown -R www-data:www-data /var/www && \
+    chmod -R 444 /var/www/html/* && \
+    chmod 775 /var/www/html && \
+    find /var/www/html/* -type d -exec chmod 555 {} \;
 
 EXPOSE 80
 VOLUME /var/www/documents

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -46,7 +46,7 @@ upload_max_filesize = ${PHP_INI_UPLOAD_MAX_FILESIZE}
 post_max_size = ${PHP_INI_POST_MAX_SIZE}
 allow_url_fopen = ${PHP_INI_ALLOW_URL_FOPEN}
 session.use_strict_mode = 1
-disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,passthru,shell_exec,system,proc_open,popen
+disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,passthru,shell_exec,system,proc_open,popen,dl,apache_note,apache_setenv,show_source,virtual
 EOF
 
 if [[ ! -f /var/www/html/conf/conf.php ]]; then


### PR DESCRIPTION
- disable php functions
- change directory and files permissions