### PR TITLE
Adding option to auto-activate modules at install [try 2]

### DIFF
--- a/README.template
+++ b/README.template
@@ -97,6 +97,7 @@ When setup this way, to upgrade version the use of the web interface is mandator
 | **DOLI_ADMIN_LOGIN**            | *admin*                        | Admin's login create on the first boot
 | **DOLI_ADMIN_PASSWORD**         | *admin*                        | Admin'password
 | **DOLI_URL_ROOT**               | *http://localhost*             | Url root of the Dolibarr installation
+| **DOLI_ENABLE_MODULES**         |                                | Comma-separated list of modules to be activated at install. modUser will always be activated. (Ex: `Societe,Facture,Stock`)
 | **PHP_INI_DATE_TIMEZONE**       | *UTC*                          | Default timezone on PHP
 | **PHP_INI_MEMORY_LIMIT**        | *256M*                         | PHP Memory limit
 | **PHP_INI_UPLOAD_MAX_FILESIZE** | *2M*                           | PHP Maximum allowed size for uploaded files

--- a/docker-init.php
+++ b/docker-init.php
@@ -1,6 +1,28 @@
 #!/usr/bin/env php
 <?php
 require_once '../htdocs/master.inc.php';
-require_once DOL_DOCUMENT_ROOT . '/core/modules/modUser.class.php';
-$mod = new modUser($db);
-$mod->init();
+require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+// Remove buffering to send logs to docker
+while (ob_get_level()) { ob_end_flush(); }
+
+printf("Activating module User... ");
+activateModule('modUser');
+printf("OK\n");
+
+if (!empty(getenv('DOLI_ENABLE_MODULES'))) {
+  $dirMods = array_keys(dolGetModulesDirs())[0];
+
+  $mods = explode(',', getenv('DOLI_ENABLE_MODULES'));
+  foreach ($mods as $mod) {
+    $modName = 'mod'.$mod;
+    $modFile = $modName.'.class.php';
+    if (file_exists($dirMods.$modFile) ) {
+      printf("Activating module ".$mod." ...");
+      activateModule('mod' . $mod);
+      printf(" OK\n");
+    }
+    else {
+      printf("Unable to find module : ".$modName."\n");
+    }
+  }
+}

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -171,6 +171,8 @@ function initializeDatabase()
 
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
+  # Update ownership after initialisation of modules
+  chown -R www-data:www-data /var/www/documents
 }
 
 function migrateDatabase()


### PR DESCRIPTION
Adding the DOLI_ENABLE_MODULES in the environment variables to be able to auto-activate modules at startup.

The module "modUser" is hardcoded to always be activated.

The selected modules simply need to be added in the environment variables of the Compose file :
```
web:
        image: tuxgasy/dolibarr:latest
        environment:
            DOLI_ENABLE_MODULES: "Societe,Facture,Stock,Propale"
```

I don't think I have the proper environment to execute update.sh, i've only updated files directly on the webinterface of Github...
