### PR TITLE
Fix inline PDF preview in expensereport

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -60,6 +60,8 @@ RUN apt-get update -y \
         default-mysql-client \
         postgresql-client \
         cron \
+        libmagickwand-dev \
+        ghostscript \
     && apt-get autoremove -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
@@ -71,6 +73,15 @@ RUN apt-get update -y \
     && docker-php-ext-install imap \
     && mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Imagick for expense report inline pdf preview
+RUN pecl install imagick
+RUN docker-php-ext-enable imagick
+
+# Set Imagick security policy to allow pdf conversion
+COPY update-imagemagick-policy.sh /usr/local/bin/update-imagemagick-policy.sh
+RUN chmod +x /usr/local/bin/update-imagemagick-policy.sh
+RUN /usr/local/bin/update-imagemagick-policy.sh
 
 # Get Dolibarr
 RUN curl -fLSs https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.tar.gz |\

--- a/update-imagemagick-policy.sh
+++ b/update-imagemagick-policy.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# look for the path of policy.xml of ImageMagick
+POLICY_XML=$(find /etc -name "policy.xml" | grep -m 1 'ImageMagick')
+
+# If policy.xml is found ，change it to allow pdf conversion
+if [ ! -z "$POLICY_XML" ]; then
+    sed -i '/<policy domain="coder" rights="none" pattern="PDF" \/>/c\<policy domain="coder" rights="read|write" pattern="PDF" \/>' "$POLICY_XML"
+fi


### PR DESCRIPTION
In expensereport, it requires imagick and ghostscript to convert pdf and show an inline preview. This pull request is to include the installation and configuration of these packages