### PR TITLE
Add customs scripts via volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,49 @@ Environment variables that are compatible with docker secrets:
 * `DOLI_CRON_KEY` => `DOLI_CRON_KEY_FILE`
 * `DOLI_CRON_USER` => `DOLI_CRON_USER_FILE`
 * `DOLI_INSTANCE_UNIQUE_ID` => `DOLI_INSTANCE_UNIQUE_ID_FILE`
+
+## Add post-deployment scripts
+It is possible to execute `*.sql` and `*.php` custom file at the end of deployment by mounting a volume with the following structure : 
+```
+\volume
+|-\sql
+| |- custom_script.sql
+|
+|-\php
+| |- custom_script.php
+```
+
+Mount the volume with compose file : 
+```yaml
+version: "3"
+
+services:
+    mariadb:
+        image: mariadb:latest
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: dolibarr
+
+    web:
+        image: tuxgasy/dolibarr
+        environment:
+            DOLI_DB_HOST: mariadb
+            DOLI_DB_USER: root
+            DOLI_DB_PASSWORD: root
+            DOLI_DB_NAME: dolibarr
+            DOLI_URL_ROOT: 'http://0.0.0.0'
+            PHP_INI_DATE_TIMEZONE: 'Europe/Paris'
+        volumes :
+          - volume-scripts:/var/www/scripts/docker-init
+        ports:
+            - "80:80"
+        links:
+            - mariadb
+```
+
+or more specifically 
+```
+        volumes : 
+          - volume-scripts-sql:/var/www/scripts/docker-init/sql
+          - volume-scripts-php:/var/www/scripts/docker-init/php
+```

--- a/README.md
+++ b/README.md
@@ -141,14 +141,12 @@ Environment variables that are compatible with docker secrets:
 * `DOLI_INSTANCE_UNIQUE_ID` => `DOLI_INSTANCE_UNIQUE_ID_FILE`
 
 ## Add post-deployment scripts
-It is possible to execute `*.sql` and `*.php` custom file at the end of deployment by mounting a volume with the following structure : 
+It is possible to execute `*.sh`, `*.sql` and/or `*.php` custom file at the end of deployment by mounting a volume in `/var/www/scripts/docker-init.d`
 ```
 \docker-init.d
-|-\sql
-| |- custom_script.sql
-|
-|-\php
-| |- custom_script.php
+|- custom_script.sql
+|- custom_script.php
+|- custom_script.sh
 ```
 
 Mount the volume with compose file : 
@@ -177,11 +175,4 @@ services:
             - "80:80"
         links:
             - mariadb
-```
-
-or more specifically 
-```
-        volumes : 
-          - volume-scripts-sql:/var/www/scripts/docker-init.d/sql
-          - volume-scripts-php:/var/www/scripts/docker-init.d/php
 ```

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Environment variables that are compatible with docker secrets:
 ## Add post-deployment scripts
 It is possible to execute `*.sql` and `*.php` custom file at the end of deployment by mounting a volume with the following structure : 
 ```
-\volume
+\docker-init.d
 |-\sql
 | |- custom_script.sql
 |
@@ -172,7 +172,7 @@ services:
             DOLI_URL_ROOT: 'http://0.0.0.0'
             PHP_INI_DATE_TIMEZONE: 'Europe/Paris'
         volumes :
-          - volume-scripts:/var/www/scripts/docker-init
+          - volume-scripts:/var/www/scripts/docker-init.d
         ports:
             - "80:80"
         links:
@@ -182,6 +182,6 @@ services:
 or more specifically 
 ```
         volumes : 
-          - volume-scripts-sql:/var/www/scripts/docker-init/sql
-          - volume-scripts-php:/var/www/scripts/docker-init/php
+          - volume-scripts-sql:/var/www/scripts/docker-init.d/sql
+          - volume-scripts-php:/var/www/scripts/docker-init.d/php
 ```

--- a/README.template
+++ b/README.template
@@ -135,14 +135,12 @@ Environment variables that are compatible with docker secrets:
 * `DOLI_INSTANCE_UNIQUE_ID` => `DOLI_INSTANCE_UNIQUE_ID_FILE`
 
 ## Add post-deployment scripts
-It is possible to execute `*.sql` and `*.php` custom file at the end of deployment by mounting a volume with the following structure : 
+It is possible to execute `*.sh`, `*.sql` and/or `*.php` custom file at the end of deployment by mounting a volume in `/var/www/scripts/docker-init.d`
 ```
 \docker-init.d
-|-\sql
-| |- custom_script.sql
-|
-|-\php
-| |- custom_script.php
+|- custom_script.sql
+|- custom_script.php
+|- custom_script.sh
 ```
 
 Mount the volume with compose file : 
@@ -171,11 +169,4 @@ services:
             - "80:80"
         links:
             - mariadb
-```
-
-or more specifically 
-```
-        volumes : 
-          - volume-scripts-sql:/var/www/scripts/docker-init.d/sql
-          - volume-scripts-php:/var/www/scripts/docker-init.d/php
 ```

--- a/README.template
+++ b/README.template
@@ -133,3 +133,49 @@ Environment variables that are compatible with docker secrets:
 * `DOLI_CRON_KEY` => `DOLI_CRON_KEY_FILE`
 * `DOLI_CRON_USER` => `DOLI_CRON_USER_FILE`
 * `DOLI_INSTANCE_UNIQUE_ID` => `DOLI_INSTANCE_UNIQUE_ID_FILE`
+
+## Add post-deployment scripts
+It is possible to execute `*.sql` and `*.php` custom file at the end of deployment by mounting a volume with the following structure : 
+```
+\docker-init.d
+|-\sql
+| |- custom_script.sql
+|
+|-\php
+| |- custom_script.php
+```
+
+Mount the volume with compose file : 
+```yaml
+version: "3"
+
+services:
+    mariadb:
+        image: mariadb:latest
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: dolibarr
+
+    web:
+        image: tuxgasy/dolibarr
+        environment:
+            DOLI_DB_HOST: mariadb
+            DOLI_DB_USER: root
+            DOLI_DB_PASSWORD: root
+            DOLI_DB_NAME: dolibarr
+            DOLI_URL_ROOT: 'http://0.0.0.0'
+            PHP_INI_DATE_TIMEZONE: 'Europe/Paris'
+        volumes :
+          - volume-scripts:/var/www/scripts/docker-init.d
+        ports:
+            - "80:80"
+        links:
+            - mariadb
+```
+
+or more specifically 
+```
+        volumes : 
+          - volume-scripts-sql:/var/www/scripts/docker-init.d/sql
+          - volume-scripts-php:/var/www/scripts/docker-init.d/php
+```

--- a/docker-init.php
+++ b/docker-init.php
@@ -33,12 +33,12 @@ if (!empty(getenv('DOLI_COMPANY_COUNTRYCODE'))) {
     if ($res > 0 ) {
         $s = $country->id.':'.$country->code.':'.$country->label;
         dolibarr_set_const($db, "MAIN_INFO_SOCIETE_COUNTRY", $s, 'chaine', 0, '', $conf->entity);
-        printf('Configuring for country : '.$s);
+        printf('Configuring for country : '.$s."\n");
         activateModulesRequiredByCountry($country->code);
         $db->commit();
     }
     else {
-            printf('Unable to find country '.$countryCode);
+            printf('Unable to find country '.$countryCode."\n");
     }
 }
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -172,6 +172,19 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
+  if [ -d /var/www/scripts/docker-init.d/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      echo "Importing custom SQL from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL}
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+    done
+
+    for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      echo "Executing custom PHP : `basename ${filePHP}` ..."
+      php $filePHP
+    done
+  fi
+
   # Update ownership after initialisation of modules
   chown -R www-data:www-data /var/www/documents
 }

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -174,12 +174,14 @@ function initializeDatabase()
 
   if [ -d /var/www/scripts/docker-init.d/sql ] ; then
     for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      [ ! -f $fileSQL ] && continue ;
       echo "Importing custom SQL from `basename ${fileSQL}` ..."
       sed -i 's/--.*//g;' ${fileSQL}
       mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
     done
 
     for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      [ ! -f $filePHP ] && continue ;
       echo "Executing custom PHP : `basename ${filePHP}` ..."
       php $filePHP
     done

--- a/images/15.0.3-php7.4/docker-init.php
+++ b/images/15.0.3-php7.4/docker-init.php
@@ -33,12 +33,12 @@ if (!empty(getenv('DOLI_COMPANY_COUNTRYCODE'))) {
     if ($res > 0 ) {
         $s = $country->id.':'.$country->code.':'.$country->label;
         dolibarr_set_const($db, "MAIN_INFO_SOCIETE_COUNTRY", $s, 'chaine', 0, '', $conf->entity);
-        printf('Configuring for country : '.$s);
+        printf('Configuring for country : '.$s."\n");
         activateModulesRequiredByCountry($country->code);
         $db->commit();
     }
     else {
-            printf('Unable to find country '.$countryCode);
+            printf('Unable to find country '.$countryCode."\n");
     }
 }
 

--- a/images/15.0.3-php7.4/docker-run.sh
+++ b/images/15.0.3-php7.4/docker-run.sh
@@ -172,14 +172,16 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
-  if [ -d /var/www/scripts/docker-init/sql ] ; then
-    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+  if [ -d /var/www/scripts/docker-init.d/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      [ ! -f $fileSQL ] && continue ;
       echo "Importing custom SQL from `basename ${fileSQL}` ..."
       sed -i 's/--.*//g;' ${fileSQL}
       mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
     done
 
-    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+    for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      [ ! -f $filePHP ] && continue ;
       echo "Executing custom PHP : `basename ${filePHP}` ..."
       php $filePHP
     done

--- a/images/15.0.3-php7.4/docker-run.sh
+++ b/images/15.0.3-php7.4/docker-run.sh
@@ -172,6 +172,19 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
+  if [ -d /var/www/scripts/docker-init/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+      echo "Importing custom SQL from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL}
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+    done
+
+    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+      echo "Executing custom PHP : `basename ${filePHP}` ..."
+      php $filePHP
+    done
+  fi
+
   # Update ownership after initialisation of modules
   chown -R www-data:www-data /var/www/documents
 }

--- a/images/16.0.5-php8.1/docker-init.php
+++ b/images/16.0.5-php8.1/docker-init.php
@@ -33,12 +33,12 @@ if (!empty(getenv('DOLI_COMPANY_COUNTRYCODE'))) {
     if ($res > 0 ) {
         $s = $country->id.':'.$country->code.':'.$country->label;
         dolibarr_set_const($db, "MAIN_INFO_SOCIETE_COUNTRY", $s, 'chaine', 0, '', $conf->entity);
-        printf('Configuring for country : '.$s);
+        printf('Configuring for country : '.$s."\n");
         activateModulesRequiredByCountry($country->code);
         $db->commit();
     }
     else {
-            printf('Unable to find country '.$countryCode);
+            printf('Unable to find country '.$countryCode."\n");
     }
 }
 

--- a/images/16.0.5-php8.1/docker-run.sh
+++ b/images/16.0.5-php8.1/docker-run.sh
@@ -172,14 +172,16 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
-  if [ -d /var/www/scripts/docker-init/sql ] ; then
-    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+  if [ -d /var/www/scripts/docker-init.d/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      [ ! -f $fileSQL ] && continue ;
       echo "Importing custom SQL from `basename ${fileSQL}` ..."
       sed -i 's/--.*//g;' ${fileSQL}
       mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
     done
 
-    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+    for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      [ ! -f $filePHP ] && continue ;
       echo "Executing custom PHP : `basename ${filePHP}` ..."
       php $filePHP
     done

--- a/images/16.0.5-php8.1/docker-run.sh
+++ b/images/16.0.5-php8.1/docker-run.sh
@@ -172,6 +172,19 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
+  if [ -d /var/www/scripts/docker-init/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+      echo "Importing custom SQL from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL}
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+    done
+
+    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+      echo "Executing custom PHP : `basename ${filePHP}` ..."
+      php $filePHP
+    done
+  fi
+
   # Update ownership after initialisation of modules
   chown -R www-data:www-data /var/www/documents
 }

--- a/images/17.0.4-php8.1/docker-init.php
+++ b/images/17.0.4-php8.1/docker-init.php
@@ -33,12 +33,12 @@ if (!empty(getenv('DOLI_COMPANY_COUNTRYCODE'))) {
     if ($res > 0 ) {
         $s = $country->id.':'.$country->code.':'.$country->label;
         dolibarr_set_const($db, "MAIN_INFO_SOCIETE_COUNTRY", $s, 'chaine', 0, '', $conf->entity);
-        printf('Configuring for country : '.$s);
+        printf('Configuring for country : '.$s."\n");
         activateModulesRequiredByCountry($country->code);
         $db->commit();
     }
     else {
-            printf('Unable to find country '.$countryCode);
+            printf('Unable to find country '.$countryCode."\n");
     }
 }
 

--- a/images/17.0.4-php8.1/docker-run.sh
+++ b/images/17.0.4-php8.1/docker-run.sh
@@ -172,14 +172,16 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
-  if [ -d /var/www/scripts/docker-init/sql ] ; then
-    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+  if [ -d /var/www/scripts/docker-init.d/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      [ ! -f $fileSQL ] && continue ;
       echo "Importing custom SQL from `basename ${fileSQL}` ..."
       sed -i 's/--.*//g;' ${fileSQL}
       mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
     done
 
-    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+    for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      [ ! -f $filePHP ] && continue ;
       echo "Executing custom PHP : `basename ${filePHP}` ..."
       php $filePHP
     done

--- a/images/17.0.4-php8.1/docker-run.sh
+++ b/images/17.0.4-php8.1/docker-run.sh
@@ -172,6 +172,19 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
+  if [ -d /var/www/scripts/docker-init/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+      echo "Importing custom SQL from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL}
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+    done
+
+    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+      echo "Executing custom PHP : `basename ${filePHP}` ..."
+      php $filePHP
+    done
+  fi
+
   # Update ownership after initialisation of modules
   chown -R www-data:www-data /var/www/documents
 }

--- a/images/18.0.5-php8.1/docker-init.php
+++ b/images/18.0.5-php8.1/docker-init.php
@@ -33,12 +33,12 @@ if (!empty(getenv('DOLI_COMPANY_COUNTRYCODE'))) {
     if ($res > 0 ) {
         $s = $country->id.':'.$country->code.':'.$country->label;
         dolibarr_set_const($db, "MAIN_INFO_SOCIETE_COUNTRY", $s, 'chaine', 0, '', $conf->entity);
-        printf('Configuring for country : '.$s);
+        printf('Configuring for country : '.$s."\n");
         activateModulesRequiredByCountry($country->code);
         $db->commit();
     }
     else {
-            printf('Unable to find country '.$countryCode);
+            printf('Unable to find country '.$countryCode."\n");
     }
 }
 

--- a/images/18.0.5-php8.1/docker-run.sh
+++ b/images/18.0.5-php8.1/docker-run.sh
@@ -172,14 +172,16 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
-  if [ -d /var/www/scripts/docker-init/sql ] ; then
-    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+  if [ -d /var/www/scripts/docker-init.d/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      [ ! -f $fileSQL ] && continue ;
       echo "Importing custom SQL from `basename ${fileSQL}` ..."
       sed -i 's/--.*//g;' ${fileSQL}
       mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
     done
 
-    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+    for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      [ ! -f $filePHP ] && continue ;
       echo "Executing custom PHP : `basename ${filePHP}` ..."
       php $filePHP
     done

--- a/images/18.0.5-php8.1/docker-run.sh
+++ b/images/18.0.5-php8.1/docker-run.sh
@@ -172,6 +172,19 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
+  if [ -d /var/www/scripts/docker-init/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+      echo "Importing custom SQL from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL}
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+    done
+
+    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+      echo "Executing custom PHP : `basename ${filePHP}` ..."
+      php $filePHP
+    done
+  fi
+
   # Update ownership after initialisation of modules
   chown -R www-data:www-data /var/www/documents
 }

--- a/images/19.0.1-php8.2/docker-init.php
+++ b/images/19.0.1-php8.2/docker-init.php
@@ -33,12 +33,12 @@ if (!empty(getenv('DOLI_COMPANY_COUNTRYCODE'))) {
     if ($res > 0 ) {
         $s = $country->id.':'.$country->code.':'.$country->label;
         dolibarr_set_const($db, "MAIN_INFO_SOCIETE_COUNTRY", $s, 'chaine', 0, '', $conf->entity);
-        printf('Configuring for country : '.$s);
+        printf('Configuring for country : '.$s."\n");
         activateModulesRequiredByCountry($country->code);
         $db->commit();
     }
     else {
-            printf('Unable to find country '.$countryCode);
+            printf('Unable to find country '.$countryCode."\n");
     }
 }
 

--- a/images/19.0.1-php8.2/docker-run.sh
+++ b/images/19.0.1-php8.2/docker-run.sh
@@ -172,14 +172,16 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
-  if [ -d /var/www/scripts/docker-init/sql ] ; then
-    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+  if [ -d /var/www/scripts/docker-init.d/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      [ ! -f $fileSQL ] && continue ;
       echo "Importing custom SQL from `basename ${fileSQL}` ..."
       sed -i 's/--.*//g;' ${fileSQL}
       mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
     done
 
-    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+    for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      [ ! -f $filePHP ] && continue ;
       echo "Executing custom PHP : `basename ${filePHP}` ..."
       php $filePHP
     done

--- a/images/19.0.1-php8.2/docker-run.sh
+++ b/images/19.0.1-php8.2/docker-run.sh
@@ -172,6 +172,19 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
+  if [ -d /var/www/scripts/docker-init/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+      echo "Importing custom SQL from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL}
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+    done
+
+    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+      echo "Executing custom PHP : `basename ${filePHP}` ..."
+      php $filePHP
+    done
+  fi
+
   # Update ownership after initialisation of modules
   chown -R www-data:www-data /var/www/documents
 }

--- a/images/develop/docker-init.php
+++ b/images/develop/docker-init.php
@@ -33,12 +33,12 @@ if (!empty(getenv('DOLI_COMPANY_COUNTRYCODE'))) {
     if ($res > 0 ) {
         $s = $country->id.':'.$country->code.':'.$country->label;
         dolibarr_set_const($db, "MAIN_INFO_SOCIETE_COUNTRY", $s, 'chaine', 0, '', $conf->entity);
-        printf('Configuring for country : '.$s);
+        printf('Configuring for country : '.$s."\n");
         activateModulesRequiredByCountry($country->code);
         $db->commit();
     }
     else {
-            printf('Unable to find country '.$countryCode);
+            printf('Unable to find country '.$countryCode."\n");
     }
 }
 

--- a/images/develop/docker-run.sh
+++ b/images/develop/docker-run.sh
@@ -172,14 +172,16 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
-  if [ -d /var/www/scripts/docker-init/sql ] ; then
-    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+  if [ -d /var/www/scripts/docker-init.d/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init.d/sql/*.sql; do
+      [ ! -f $fileSQL ] && continue ;
       echo "Importing custom SQL from `basename ${fileSQL}` ..."
       sed -i 's/--.*//g;' ${fileSQL}
       mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
     done
 
-    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+    for filePHP in /var/www/scripts/docker-init.d/php/*.php; do
+      [ ! -f $filePHP ] && continue ;
       echo "Executing custom PHP : `basename ${filePHP}` ..."
       php $filePHP
     done

--- a/images/develop/docker-run.sh
+++ b/images/develop/docker-run.sh
@@ -172,6 +172,19 @@ function initializeDatabase()
   echo "Enable user module ..."
   php /var/www/scripts/docker-init.php
 
+  if [ -d /var/www/scripts/docker-init/sql ] ; then
+    for fileSQL in /var/www/scripts/docker-init/sql/*.sql; do
+      echo "Importing custom SQL from `basename ${fileSQL}` ..."
+      sed -i 's/--.*//g;' ${fileSQL}
+      mysql -u ${DOLI_DB_USER} -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} ${DOLI_DB_NAME} < ${fileSQL} > /dev/null 2>&1
+    done
+
+    for filePHP in /var/www/scripts/docker-init/php/*.php; do
+      echo "Executing custom PHP : `basename ${filePHP}` ..."
+      php $filePHP
+    done
+  fi
+
   # Update ownership after initialisation of modules
   chown -R www-data:www-data /var/www/documents
 }


### PR DESCRIPTION
Hi,

As i need to configure some things after the deployment of this image, i suggest to add this functionality.

By adding mount volume inside the container at : 
- /var/www/scripts/docker-init.d/php
- /var/www/scripts/docker-init.d/sql

We can use these folder to store scripts and sql files to be executed at the end of the deployment, at the end of the function "initializeDatabase" inside docker-run.sh, the same way as docker-init.php

I don't know what would be the best to the names of folders or other things, but the functionality will allow to automate and set up template on new deployments.

And will allow me to customize without creating lot of PR :wink: