### PR TITLE
fix: handle special characters in DB password including double quotes

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -113,7 +113,7 @@ function waitForDataBase()
   r=1
 
   while [[ ${r} -ne 0 ]]; do
-    mysql -u ${DOLI_DB_USER} --protocol tcp -p${DOLI_DB_PASSWORD} -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} --connect-timeout=5 -e "status" > /dev/null 2>&1
+    mysql -u ${DOLI_DB_USER} --protocol tcp -p"${DOLI_DB_PASSWORD}" -h ${DOLI_DB_HOST} -P ${DOLI_DB_HOST_PORT} --connect-timeout=5 -e "status" > /dev/null 2>&1
     r=$?
     if [[ ${r} -ne 0 ]]; then
       echo "Waiting that SQL database is up ..."


### PR DESCRIPTION
- Added double quotes around ${DOLI_DB_PASSWORD} to ensure special characters are correctly handled.

My database password contained SPACE characters. For this reason, my Dolibarr installation was stuck in a loop "Waiting that SQL database is up ..."