### PR TITLE
Remove version from Docker compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Let's use [Docker Compose](https://docs.docker.com/compose/) to integrate it wit
 Create `docker-compose.yml` file as following:
 
 ```yaml
-version: "3"
-
 services:
     mariadb:
         image: mariadb:latest
@@ -151,8 +149,6 @@ It is possible to execute `*.sh`, `*.sql` and/or `*.php` custom file at the end 
 
 Mount the volume with compose file : 
 ```yaml
-version: "3"
-
 services:
     mariadb:
         image: mariadb:latest

--- a/README.template
+++ b/README.template
@@ -30,8 +30,6 @@ Let's use [Docker Compose](https://docs.docker.com/compose/) to integrate it wit
 Create `docker-compose.yml` file as following:
 
 ```yaml
-version: "3"
-
 services:
     mariadb:
         image: mariadb:latest
@@ -145,8 +143,6 @@ It is possible to execute `*.sh`, `*.sql` and/or `*.php` custom file at the end 
 
 Mount the volume with compose file : 
 ```yaml
-version: "3"
-
 services:
     mariadb:
         image: mariadb:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@
 #
 # More information about Docker-compose : https://docs.docker.com/compose/
 
-version: "3.8"
-
 networks:
     internal-pod:
         internal: true

--- a/examples/with-certbot/docker-compose.yml
+++ b/examples/with-certbot/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   db:
     image: mysql:8.0.20

--- a/examples/with-mysql/docker-compose.yml
+++ b/examples/with-mysql/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   internal-pod:
     internal: true

--- a/examples/with-pgsql/docker-compose.yml
+++ b/examples/with-pgsql/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   internal-pod:
     internal: true

--- a/examples/with-rp-traefik/docker-compose.yml
+++ b/examples/with-rp-traefik/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   proxy-network:
     name: proxy-network

--- a/examples/with-secrets/docker-compose.yml
+++ b/examples/with-secrets/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   internal-pod:
     internal: true


### PR DESCRIPTION
In docker-compose file the "version" is obsolete and generate warning.
Remove "version" from all docker-compose files.